### PR TITLE
Add installation guide with homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ cd ohsome-planet
 ./mvnw clean package -DskipTests
 ```
 
+## Installation for Mac with Homebrew
+```sh
+brew install GIScience/tap/ohsome-planet --build-from-source
+ohsome-planet contributions --help
+```
+
 ## Run
 You can download the [full latest or history planet](https://planet.openstreetmap.org/pbf/full-history/) 
 or download PBF files for smaller regions from [Geofabrik](https://osm-internal.download.geofabrik.de/).


### PR DESCRIPTION
Hey,

I really admire that you have created such a nice tool and this really helps querying OSM data when using duckdb since geoparquet works way better with it compared to `.osm.pbf`.

How ever the installation guide is pretty complex for dummies like me and I think it would help with the adoption if you would provide oneliner to install with homebrew. Thanks a lot for releasing this great tool 🙇🚀

## Requirements before merging
Currently these steps will not work before you will actually fork the homebrew formula from my repository https://github.com/onnimonni/homebrew-ohsome-planet

In order to do this you need to for example run following commands:
```sh
$ git clone https://github.com/onnimonni/homebrew-ohsome-planet
$ cd homebrew-ohsome-planet
$ gh repo fork --org GIScience --fork-name homebrew-tap
$ git push origin main
```
**Ensure that the fork will go into `GIScience/homebrew-tap`**

## Why would we not add it directly to homebrew?

I tried this already but it can't yet be added into hombrew formulas because they have silly rules like these:

```sh
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --new ohsome-planet
ohsome-planet
  * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
```
  
Once the ohsome-planet has enough forks/watchers/stars we can remove this repository and add it directly to homebrew.

## To test the installation on Mac from my repository

```
# Install latest from the main branch
$ brew install onnimonni/ohsome-planet/ohsome-planet --build-from-source

# Install latest release 1.1.0
$ brew install onnimonni/ohsome-planet/ohsome-planet
```