### PR TITLE
Keep thread count to a minimum of 1

### DIFF
--- a/ohsome-contributions/src/main/java/org/heigit/ohsome/contributions/Contributions2Parquet.java
+++ b/ohsome-contributions/src/main/java/org/heigit/ohsome/contributions/Contributions2Parquet.java
@@ -74,7 +74,7 @@ public class Contributions2Parquet implements Callable<Integer> {
     private boolean overwrite = false;
 
     @Option(names = {"--parallel"}, description = "number of threads used for processing. Dictates the number of files which will created.")
-    private int parallel = Runtime.getRuntime().availableProcessors() - 1;
+    private int parallel = Math.max(Runtime.getRuntime().availableProcessors() - 1, 1);
 
     @Option(names = {"--country-file"})
     private Path countryFilePath;


### PR DESCRIPTION
When running without specifying `--parallel 1` on a single-core machine, the program will error out with a divide-by-zero error.

Output:

```
read blocks 100% │█████████│ 90189/90189 MiB (0:07:54 / 0:00:00) 1420540 blocks
java.lang.ArithmeticException: / by zero
        at org.heigit.ohsome.contributions.transformer.Transformer.blocksPerChunk(Transformer.java:61)
        at org.heigit.ohsome.contributions.transformer.Transformer.process(Transformer.java:80)
        at org.heigit.ohsome.contributions.transformer.TransformerNodes.processNodes(TransformerNodes.java:46)
        at org.heigit.ohsome.contributions.Contributions2Parquet.call(Contributions2Parquet.java:135)
        at org.heigit.ohsome.contributions.Contributions2Parquet.call(Contributions2Parquet.java:61)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2045)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at org.heigit.ohsome.planet.OhsomePlanet.main(OhsomePlanet.java:29)
```